### PR TITLE
Handle deleted/unmanaged files for new module

### DIFF
--- a/lib/pdk/generate/module.rb
+++ b/lib/pdk/generate/module.rb
@@ -58,7 +58,8 @@ module PDK
 
         begin
           PDK::Module::TemplateDir.new(template_uri, metadata.data, true) do |templates|
-            templates.render do |file_path, file_content|
+            templates.render do |file_path, file_content, file_status|
+              next unless file_status == :managed
               file = Pathname.new(temp_target_dir) + file_path
               file.dirname.mkpath
               write_file(file, file_content)


### PR DESCRIPTION
When creating a new module, only process templates for files which
are not marked as deleted or unmanaged. This permits non-standard
PDK templates with files set to delete or unmanaged to be used
for new module creation without error.